### PR TITLE
Adding Deprecation message now that this feature is part of vscode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
-# Deprecated
-This feature now ships with visual studio code!
+# :rotating_light: Deprecated :rotating_light: - This feature is now part of VSCode
+[This feature](https://github.com/Microsoft/vscode/issues/8102) now ships with visual studio code!
 
-[The feature request](https://github.com/Microsoft/vscode/issues/8102)
+Steps to using built-in workspace snippets:
+- Create a `{namehere}.code-snippets` file in `.vscode` folder
+- The file must be within `.vscode` folder (not in sub-folders)
+- Your snippets can now be checked in and shared with your team
+- Note: when using the snippet you will see `(Workspace Snippet)` in the intellisense autocomplete dropdown
 
-View the offical microsoft steps here
+
+--------
 
 # project snippets [![Build Status](https://travis-ci.org/rebornix/vscode-project-snippet.svg?branch=master)](https://travis-ci.org/rebornix/vscode-project-snippet) [![Build status](https://ci.appveyor.com/api/projects/status/0ntf4072cfp2naig/branch/master?svg=true)](https://ci.appveyor.com/project/rebornix/vscode-project-snippet/branch/master)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# Deprecated
+This feature now ships with visual studio code!
+
+[The feature request](https://github.com/Microsoft/vscode/issues/8102)
+
+View the offical microsoft steps here
+
 # project snippets [![Build Status](https://travis-ci.org/rebornix/vscode-project-snippet.svg?branch=master)](https://travis-ci.org/rebornix/vscode-project-snippet) [![Build status](https://ci.appveyor.com/api/projects/status/0ntf4072cfp2naig/branch/master?svg=true)](https://ci.appveyor.com/project/rebornix/vscode-project-snippet/branch/master)
 
 


### PR DESCRIPTION
When I was searching for vscode snippet workspace support I found your medium post and this library,

I had to do some more digging to find this feature ships with vscode now. Looks like you went though the [issue backlog already](https://github.com/Microsoft/vscode/issues/8102) so I'm adding a message to point people to the built-in feature :D